### PR TITLE
Handle empty VSS commit messages properly

### DIFF
--- a/Vss2Git/GitExporter.cs
+++ b/Vss2Git/GitExporter.cs
@@ -32,7 +32,8 @@ namespace Hpdi.Vss2Git
     /// <author>Trevor Robinson</author>
     class GitExporter : Worker
     {
-        private const string DefaultComment = "Vss2Git";
+        // Empty comment by default
+        private const string DefaultComment = "";
 
         private readonly VssDatabase database;
         private readonly RevisionAnalyzer revisionAnalyzer;

--- a/Vss2Git/GitWrapper.cs
+++ b/Vss2Git/GitWrapper.cs
@@ -182,7 +182,11 @@ namespace Hpdi.Vss2Git
         private void AddComment(string comment, ref string args, out TempFile tempFile)
         {
             tempFile = null;
-            if (!string.IsNullOrEmpty(comment))
+            if (string.IsNullOrEmpty(comment))
+            {
+                args += " --allow-empty-message --no-edit -m \"\"";
+            }
+            else
             {
                 // need to use a temporary file to specify the comment when not
                 // using the system default code page or it contains newlines

--- a/Vss2Git/VssPathMapper.cs
+++ b/Vss2Git/VssPathMapper.cs
@@ -585,7 +585,7 @@ namespace Hpdi.Vss2Git
         {
             if (!projectSpec.StartsWith("$/"))
             {
-                throw new ArgumentException("Project spec must start with $/", "projectSpec");
+                throw new ArgumentException("Project spec must start with $/ but was \"" + projectSpec + "\"", "projectSpec");
             }
 
             foreach (var rootInfo in rootInfos.Values)


### PR DESCRIPTION
Enable importing commits with empty commit message "as is", without meaningless "Vss2Git" message text.