### PR TITLE
New feature: Option to ignore Git errors.

### DIFF
--- a/Vss2Git/GitExporter.cs
+++ b/Vss2Git/GitExporter.cs
@@ -39,6 +39,7 @@ namespace Hpdi.Vss2Git
         private readonly ChangesetBuilder changesetBuilder;
         private readonly StreamCopier streamCopier = new StreamCopier();
         private readonly HashSet<string> tagsUsed = new HashSet<string>();
+        private bool ignoreErrors = false;
 
         private string emailDomain = "localhost";
         public string EmailDomain
@@ -59,6 +60,12 @@ namespace Hpdi.Vss2Git
         {
             get { return forceAnnotatedTags; }
             set { forceAnnotatedTags = value; }
+        }
+
+        public bool IgnoreErrors
+        {
+            get { return ignoreErrors; }
+            set { ignoreErrors = value; }
         }
 
         public GitExporter(WorkQueue workQueue, Logger logger,
@@ -598,6 +605,12 @@ namespace Hpdi.Vss2Git
                     var message = LogException(e);
 
                     message += "\nSee log file for more information.";
+
+                    if (ignoreErrors)
+                    {
+                        retry = false;
+                        continue;
+                    }
 
                     var button = MessageBox.Show(message, "Error", buttons, MessageBoxIcon.Error);
                     switch (button)

--- a/Vss2Git/MainForm.Designer.cs
+++ b/Vss2Git/MainForm.Designer.cs
@@ -64,6 +64,7 @@
             this.label2 = new System.Windows.Forms.Label();
             this.label1 = new System.Windows.Forms.Label();
             this.anyCommentUpDown = new System.Windows.Forms.NumericUpDown();
+            this.ignoreErrorsCheckBox = new System.Windows.Forms.CheckBox();
             this.vssGroupBox.SuspendLayout();
             this.statusStrip.SuspendLayout();
             this.outputGroupBox.SuspendLayout();
@@ -230,6 +231,7 @@
             // 
             this.outputGroupBox.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left)
                         | System.Windows.Forms.AnchorStyles.Right)));
+            this.outputGroupBox.Controls.Add(this.ignoreErrorsCheckBox);
             this.outputGroupBox.Controls.Add(this.forceAnnotatedCheckBox);
             this.outputGroupBox.Controls.Add(this.transcodeCheckBox);
             this.outputGroupBox.Controls.Add(this.domainTextBox);
@@ -409,6 +411,17 @@
             this.anyCommentUpDown.Name = "anyCommentUpDown";
             this.anyCommentUpDown.Size = new System.Drawing.Size(54, 20);
             this.anyCommentUpDown.TabIndex = 1;
+            //
+            // ignoreErrorsCheckBox
+            //
+            this.ignoreErrorsCheckBox.AutoSize = true;
+            this.ignoreErrorsCheckBox.Location = new System.Drawing.Point(422, 97);
+            this.ignoreErrorsCheckBox.Name = "ignoreErrorsCheckBox";
+            this.ignoreErrorsCheckBox.RightToLeft = System.Windows.Forms.RightToLeft.No;
+            this.ignoreErrorsCheckBox.Size = new System.Drawing.Size(101, 17);
+            this.ignoreErrorsCheckBox.TabIndex = 8;
+            this.ignoreErrorsCheckBox.Text = "Ignore Git errors";
+            this.ignoreErrorsCheckBox.UseVisualStyleBackColor = true;
             // 
             // MainForm
             // 
@@ -481,7 +494,7 @@
         private System.Windows.Forms.ComboBox encodingComboBox;
         private System.Windows.Forms.CheckBox transcodeCheckBox;
         private System.Windows.Forms.CheckBox forceAnnotatedCheckBox;
-
+        private System.Windows.Forms.CheckBox ignoreErrorsCheckBox;
     }
 }
 

--- a/Vss2Git/MainForm.cs
+++ b/Vss2Git/MainForm.cs
@@ -65,6 +65,8 @@ namespace Hpdi.Vss2Git
                     encoding.EncodingName, encoding.CodePage, encoding.WebName);
                 logger.WriteLine("Comment transcoding: {0}",
                     transcodeCheckBox.Checked ? "enabled" : "disabled");
+                logger.WriteLine("Ignore errors: {0}",
+                    ignoreErrorsCheckBox.Checked ? "enabled" : "disabled");
 
                 var df = new VssDatabaseFactory(vssDirTextBox.Text);
                 df.Encoding = encoding;
@@ -115,6 +117,7 @@ namespace Hpdi.Vss2Git
                     {
                         gitExporter.CommitEncoding = encoding;
                     }
+                    gitExporter.IgnoreErrors = ignoreErrorsCheckBox.Checked;
                     gitExporter.ExportToGit(outDirTextBox.Text);
                 }
 


### PR DESCRIPTION
While converting a large repository (610k revisions, 65k changesets, going back 16 years), especially for a first-pass, I discovered that having to dismiss Git errors every few hours was annoying to me. 😄  This adds a checkbox, disabled by default, to act as if you clicked "Ignore" on all Git error messages during the replay/commit process.