### PR TITLE
Adding possibility to convert multiple VSS-projects

### DIFF
--- a/Vss2Git/MainForm.Designer.cs
+++ b/Vss2Git/MainForm.Designer.cs
@@ -153,9 +153,9 @@
             this.vssProjectLabel.AutoSize = true;
             this.vssProjectLabel.Location = new System.Drawing.Point(6, 48);
             this.vssProjectLabel.Name = "vssProjectLabel";
-            this.vssProjectLabel.Size = new System.Drawing.Size(40, 13);
+            this.vssProjectLabel.Size = new System.Drawing.Size(51, 13);
             this.vssProjectLabel.TabIndex = 2;
-            this.vssProjectLabel.Text = "Project";
+            this.vssProjectLabel.Text = "Project(s)";
             // 
             // vssDirLabel
             // 

--- a/Vss2Git/MainForm.cs
+++ b/Vss2Git/MainForm.cs
@@ -72,33 +72,36 @@ namespace Hpdi.Vss2Git
                 df.Encoding = encoding;
                 var db = df.Open();
 
-                var path = vssProjectTextBox.Text;
-                VssItem item;
-                try
-                {
-                    item = db.GetItem(path);
-                }
-                catch (VssPathException ex)
-                {
-                    MessageBox.Show(ex.Message, "Invalid project path",
-                        MessageBoxButtons.OK, MessageBoxIcon.Error);
-                    return;
-                }
-
-                var project = item as VssProject;
-                if (project == null)
-                {
-                    MessageBox.Show(path + " is not a project", "Invalid project path",
-                        MessageBoxButtons.OK, MessageBoxIcon.Error);
-                    return;
-                }
-
                 revisionAnalyzer = new RevisionAnalyzer(workQueue, logger, db);
                 if (!string.IsNullOrEmpty(excludeTextBox.Text))
                 {
                     revisionAnalyzer.ExcludeFiles = excludeTextBox.Text;
                 }
-                revisionAnalyzer.AddItem(project);
+
+                var paths = vssProjectTextBox.Text.Split(new char[]{';'}, StringSplitOptions.RemoveEmptyEntries);
+                foreach(var path in paths)
+                {
+                    VssItem item;
+                    try
+                    {
+                        item = db.GetItem(path.Trim());
+                    }
+                    catch (VssPathException ex)
+                    {
+                        MessageBox.Show(ex.Message, "Invalid project path",
+                            MessageBoxButtons.OK, MessageBoxIcon.Error);
+                        return;
+                    }
+
+                    var project = item as VssProject;
+                    if (project == null)
+                    {
+                        MessageBox.Show(path + " is not a project", "Invalid project path",
+                            MessageBoxButtons.OK, MessageBoxIcon.Error);
+                        return;
+                    }
+                    revisionAnalyzer.AddItem(project);
+                }
 
                 changesetBuilder = new ChangesetBuilder(workQueue, logger, revisionAnalyzer);
                 changesetBuilder.AnyCommentThreshold = TimeSpan.FromSeconds((double)anyCommentUpDown.Value);


### PR DESCRIPTION
Adding possibility to convert multiple VSS projects by semicolon separated list in "Project(s)" field, e.g.: 
$/TestProject; $/MainProject; $/EvalProject/Code;