### PR TITLE
Release log after exception so that old log name can be used again.

### DIFF
--- a/Vss2Git/MainForm.cs
+++ b/Vss2Git/MainForm.cs
@@ -132,6 +132,8 @@ namespace Hpdi.Vss2Git
             }
             catch (Exception ex)
             {
+                logger.Dispose();
+                logger = Logger.Null;
                 ShowException(ex);
             }
         }


### PR DESCRIPTION
Hi. I had problems when there's an error in VSS access and unhandled exception occurs. Log file remains open and I had to change the file name in UI to be able to continue.
This change just releases the log file after unhandled exception.