### PR TITLE
check user-defined mapping of user names to email addresses

### DIFF
--- a/Vss2Git/GitExporter.cs
+++ b/Vss2Git/GitExporter.cs
@@ -20,6 +20,7 @@ using System.Globalization;
 using System.IO;
 using System.Text;
 using System.Text.RegularExpressions;
+using System.Xml.Linq;
 using System.Threading;
 using System.Windows.Forms;
 using Hpdi.VssLogicalLib;
@@ -39,6 +40,20 @@ namespace Hpdi.Vss2Git
         private readonly HashSet<string> tagsUsed = new HashSet<string>();
         private bool ignoreErrors = false;
         private string defaultComment = "";
+
+        private string emailMapFile = "emailmap.xml";
+        public string EmailMapFile
+        {
+            get { return emailMapFile; }
+            set { emailMapFile = value; }
+        }
+
+        private Dictionary<string, string> emailMap = new Dictionary<string, string>();
+        public System.Collections.Generic.Dictionary<string, string> EmailMap
+        {
+            get { return emailMap; }
+            set { emailMap = value; }
+        }
 
         private string emailDomain = "localhost";
         public string EmailDomain
@@ -82,6 +97,23 @@ namespace Hpdi.Vss2Git
             this.changesetBuilder = changesetBuilder;
         }
 
+        public bool ReadEmailMap()
+        {
+            try
+            {
+                XDocument xdoc = XDocument.Load(emailMapFile);
+                foreach (var map in xdoc.Elements("map"))
+                {
+                    emailMap.Add(map.Attribute("name").Value.ToLower(), map.Attribute("email").Value);
+                }
+            }
+            catch (FileNotFoundException)
+            {
+                return false;
+            }
+            return true;
+        }
+
         public void ExportToGit(string repoPath)
         {
             workQueue.AddLast(delegate(object work)
@@ -95,6 +127,19 @@ namespace Hpdi.Vss2Git
                 if (!Directory.Exists(repoPath))
                 {
                     Directory.CreateDirectory(repoPath);
+                }
+
+                while(!ReadEmailMap())
+                {
+                    var button = MessageBox.Show("Email map file not found. ",
+                        "Error", MessageBoxButtons.AbortRetryIgnore, MessageBoxIcon.Error);
+                    if (button == DialogResult.Abort)
+                    {
+                        workQueue.Abort();
+                        return;
+                    }
+                    if (button == DialogResult.Ignore)
+                        break;
                 }
 
                 var git = new GitWrapper(repoPath, logger);
@@ -638,8 +683,16 @@ namespace Hpdi.Vss2Git
 
         private string GetEmail(string user)
         {
-            // TODO: user-defined mapping of user names to email addresses
-            return user.ToLower().Replace(' ', '.') + "@" + emailDomain;
+            // check user-defined mapping of user names to email addresses
+            string username = user.ToLower();
+            string email;
+            if (emailMap.TryGetValue(username, out email))
+            {
+                if (!email.Contains("@"))
+                    email += "@" + emailDomain;
+                return email;
+            }
+            return username.Replace(' ', '.') + "@" + emailDomain;
         }
 
         private string GetTagFromLabel(string label)

--- a/Vss2Git/MainForm.Designer.cs
+++ b/Vss2Git/MainForm.Designer.cs
@@ -54,6 +54,8 @@
             this.transcodeCheckBox = new System.Windows.Forms.CheckBox();
             this.domainTextBox = new System.Windows.Forms.TextBox();
             this.domainLabel = new System.Windows.Forms.Label();
+            this.emailMapFileTextBox = new System.Windows.Forms.TextBox();
+            this.emailMapFileLabel = new System.Windows.Forms.Label();
             this.outDirTextBox = new System.Windows.Forms.TextBox();
             this.outDirLabel = new System.Windows.Forms.Label();
             this.logTextBox = new System.Windows.Forms.TextBox();
@@ -171,7 +173,7 @@
             // goButton
             // 
             this.goButton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-            this.goButton.Location = new System.Drawing.Point(416, 381);
+            this.goButton.Location = new System.Drawing.Point(416, 400);
             this.goButton.Name = "goButton";
             this.goButton.Size = new System.Drawing.Size(75, 23);
             this.goButton.TabIndex = 3;
@@ -191,7 +193,7 @@
             this.revisionLabel,
             this.changeLabel,
             this.timeLabel});
-            this.statusStrip.Location = new System.Drawing.Point(0, 407);
+            this.statusStrip.Location = new System.Drawing.Point(0, 433);
             this.statusStrip.Name = "statusStrip";
             this.statusStrip.Size = new System.Drawing.Size(584, 22);
             this.statusStrip.TabIndex = 5;
@@ -240,13 +242,15 @@
             this.outputGroupBox.Controls.Add(this.transcodeCheckBox);
             this.outputGroupBox.Controls.Add(this.domainTextBox);
             this.outputGroupBox.Controls.Add(this.domainLabel);
+            this.outputGroupBox.Controls.Add(this.emailMapFileTextBox);
+            this.outputGroupBox.Controls.Add(this.emailMapFileLabel);
             this.outputGroupBox.Controls.Add(this.outDirTextBox);
             this.outputGroupBox.Controls.Add(this.outDirLabel);
             this.outputGroupBox.Controls.Add(this.logTextBox);
             this.outputGroupBox.Controls.Add(this.logLabel);
             this.outputGroupBox.Location = new System.Drawing.Point(12, 144);
             this.outputGroupBox.Name = "outputGroupBox";
-            this.outputGroupBox.Size = new System.Drawing.Size(560, 150);
+            this.outputGroupBox.Size = new System.Drawing.Size(560, 169);
             this.outputGroupBox.TabIndex = 1;
             this.outputGroupBox.TabStop = false;
             this.outputGroupBox.Text = "Output Settings";
@@ -255,7 +259,7 @@
             // 
             this.commentTextBox.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-            this.commentTextBox.Location = new System.Drawing.Point(94, 97);
+            this.commentTextBox.Location = new System.Drawing.Point(94, 123);
             this.commentTextBox.Name = "commentTextBox";
             this.commentTextBox.Size = new System.Drawing.Size(460, 20);
             this.commentTextBox.TabIndex = 6;
@@ -263,7 +267,7 @@
             // commentLabel
             // 
             this.commentLabel.AutoSize = true;
-            this.commentLabel.Location = new System.Drawing.Point(6, 100);
+            this.commentLabel.Location = new System.Drawing.Point(6, 126);
             this.commentLabel.Name = "commentLabel";
             this.commentLabel.Size = new System.Drawing.Size(88, 13);
             this.commentLabel.TabIndex = 8;
@@ -274,7 +278,7 @@
             this.forceAnnotatedCheckBox.AutoSize = true;
             this.forceAnnotatedCheckBox.Checked = true;
             this.forceAnnotatedCheckBox.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.forceAnnotatedCheckBox.Location = new System.Drawing.Point(224, 123);
+            this.forceAnnotatedCheckBox.Location = new System.Drawing.Point(224, 149);
             this.forceAnnotatedCheckBox.Name = "forceAnnotatedCheckBox";
             this.forceAnnotatedCheckBox.Size = new System.Drawing.Size(191, 17);
             this.forceAnnotatedCheckBox.TabIndex = 7;
@@ -286,7 +290,7 @@
             this.transcodeCheckBox.AutoSize = true;
             this.transcodeCheckBox.Checked = true;
             this.transcodeCheckBox.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.transcodeCheckBox.Location = new System.Drawing.Point(9, 123);
+            this.transcodeCheckBox.Location = new System.Drawing.Point(9, 149);
             this.transcodeCheckBox.Name = "transcodeCheckBox";
             this.transcodeCheckBox.Size = new System.Drawing.Size(209, 17);
             this.transcodeCheckBox.TabIndex = 6;
@@ -301,6 +305,24 @@
             this.domainTextBox.Name = "domainTextBox";
             this.domainTextBox.Size = new System.Drawing.Size(460, 20);
             this.domainTextBox.TabIndex = 3;
+            // 
+            // emailMapFileTextBox
+            // 
+            this.emailMapFileTextBox.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.emailMapFileTextBox.Location = new System.Drawing.Point(94, 71);
+            this.emailMapFileTextBox.Name = "emailMapFileTextBox";
+            this.emailMapFileTextBox.Size = new System.Drawing.Size(460, 20);
+            this.emailMapFileTextBox.TabIndex = 3;
+            // 
+            // emailMapFileLabel
+            // 
+            this.emailMapFileLabel.AutoSize = true;
+            this.emailMapFileLabel.Location = new System.Drawing.Point(6, 74);
+            this.emailMapFileLabel.Name = "emailMapFileLabel";
+            this.emailMapFileLabel.Size = new System.Drawing.Size(71, 13);
+            this.emailMapFileLabel.TabIndex = 2;
+            this.emailMapFileLabel.Text = "Email map file";
             // 
             // domainLabel
             // 
@@ -333,7 +355,7 @@
             // 
             this.logTextBox.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left)
                         | System.Windows.Forms.AnchorStyles.Right)));
-            this.logTextBox.Location = new System.Drawing.Point(94, 71);
+            this.logTextBox.Location = new System.Drawing.Point(94, 97);
             this.logTextBox.Name = "logTextBox";
             this.logTextBox.Size = new System.Drawing.Size(460, 20);
             this.logTextBox.TabIndex = 5;
@@ -341,7 +363,7 @@
             // logLabel
             // 
             this.logLabel.AutoSize = true;
-            this.logLabel.Location = new System.Drawing.Point(6, 74);
+            this.logLabel.Location = new System.Drawing.Point(6, 100);
             this.logLabel.Name = "logLabel";
             this.logLabel.Size = new System.Drawing.Size(41, 13);
             this.logLabel.TabIndex = 4;
@@ -351,7 +373,7 @@
             // 
             this.cancelButton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
             this.cancelButton.DialogResult = System.Windows.Forms.DialogResult.Cancel;
-            this.cancelButton.Location = new System.Drawing.Point(497, 381);
+            this.cancelButton.Location = new System.Drawing.Point(497, 400);
             this.cancelButton.Name = "cancelButton";
             this.cancelButton.Size = new System.Drawing.Size(75, 23);
             this.cancelButton.TabIndex = 4;
@@ -367,7 +389,7 @@
             this.changesetGroupBox.Controls.Add(this.label2);
             this.changesetGroupBox.Controls.Add(this.label1);
             this.changesetGroupBox.Controls.Add(this.anyCommentUpDown);
-            this.changesetGroupBox.Location = new System.Drawing.Point(12, 300);
+            this.changesetGroupBox.Location = new System.Drawing.Point(12, 319);
             this.changesetGroupBox.Name = "changesetGroupBox";
             this.changesetGroupBox.Size = new System.Drawing.Size(560, 75);
             this.changesetGroupBox.TabIndex = 2;
@@ -437,7 +459,7 @@
             // ignoreErrorsCheckBox
             //
             this.ignoreErrorsCheckBox.AutoSize = true;
-            this.ignoreErrorsCheckBox.Location = new System.Drawing.Point(422, 97);
+            this.ignoreErrorsCheckBox.Location = new System.Drawing.Point(422, 149);
             this.ignoreErrorsCheckBox.Name = "ignoreErrorsCheckBox";
             this.ignoreErrorsCheckBox.RightToLeft = System.Windows.Forms.RightToLeft.No;
             this.ignoreErrorsCheckBox.Size = new System.Drawing.Size(101, 17);
@@ -451,7 +473,7 @@
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.CancelButton = this.cancelButton;
-            this.ClientSize = new System.Drawing.Size(584, 429);
+            this.ClientSize = new System.Drawing.Size(584, 455);
             this.Controls.Add(this.changesetGroupBox);
             this.Controls.Add(this.cancelButton);
             this.Controls.Add(this.outputGroupBox);
@@ -502,6 +524,8 @@
         private System.Windows.Forms.Label outDirLabel;
         private System.Windows.Forms.TextBox domainTextBox;
         private System.Windows.Forms.Label domainLabel;
+        private System.Windows.Forms.TextBox emailMapFileTextBox;
+        private System.Windows.Forms.Label emailMapFileLabel;
         private System.Windows.Forms.TextBox excludeTextBox;
         private System.Windows.Forms.Label excludeLabel;
         private System.Windows.Forms.Button cancelButton;

--- a/Vss2Git/MainForm.cs
+++ b/Vss2Git/MainForm.cs
@@ -113,6 +113,10 @@ namespace Hpdi.Vss2Git
                     {
                         gitExporter.EmailDomain = domainTextBox.Text;
                     }
+                    if (!string.IsNullOrEmpty(emailMapFileTextBox.Text))
+                    {
+                        gitExporter.EmailMapFile = emailMapFileTextBox.Text;
+                    }
                     if (!string.IsNullOrEmpty(commentTextBox.Text))
                     {
                         gitExporter.DefaultComment = commentTextBox.Text;
@@ -234,6 +238,7 @@ namespace Hpdi.Vss2Git
             excludeTextBox.Text = settings.VssExcludePaths;
             outDirTextBox.Text = settings.GitDirectory;
             domainTextBox.Text = settings.DefaultEmailDomain;
+            emailMapFileTextBox.Text = settings.EmailMapFile;
             commentTextBox.Text = settings.DefaultComment;
             logTextBox.Text = settings.LogFile;
             transcodeCheckBox.Checked = settings.TranscodeComments;
@@ -250,6 +255,7 @@ namespace Hpdi.Vss2Git
             settings.VssExcludePaths = excludeTextBox.Text;
             settings.GitDirectory = outDirTextBox.Text;
             settings.DefaultEmailDomain = domainTextBox.Text;
+            settings.EmailMapFile = emailMapFileTextBox.Text;
             settings.LogFile = logTextBox.Text;
             settings.TranscodeComments = transcodeCheckBox.Checked;
             settings.ForceAnnotatedTags = forceAnnotatedCheckBox.Checked;

--- a/Vss2Git/Properties/Settings.Designer.cs
+++ b/Vss2Git/Properties/Settings.Designer.cs
@@ -154,5 +154,17 @@ namespace Hpdi.Vss2Git.Properties {
                 this["DefaultComment"] = value;
             }
         }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("emailmap.xml")]
+        public string EmailMapFile {
+            get {
+                return ((string)(this["EmailMapFile"]));
+            }
+            set {
+                this["EmailMapFile"] = value;
+            }
+        }
     }
 }

--- a/Vss2Git/Properties/Settings.settings
+++ b/Vss2Git/Properties/Settings.settings
@@ -35,5 +35,8 @@
     <Setting Name="DefaultComment" Type="System.String" Scope="User">
       <Value Profile="(Default)"></Value>
     </Setting>
+    <Setting Name="EmailMapFile" Type="System.String" Scope="User">
+      <Value Profile="(Default)">emailmap.xml</Value>
+    </Setting>
   </Settings>
 </SettingsFile>

--- a/Vss2Git/Vss2Git.csproj
+++ b/Vss2Git/Vss2Git.csproj
@@ -61,6 +61,8 @@
     </Reference>
     <Reference Include="System.Drawing" />
     <Reference Include="System.Windows.Forms" />
+    <Reference Include="System.XML" />
+    <Reference Include="System.Xml.Linq" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="AsyncLineReader.cs" />

--- a/Vss2Git/app.config
+++ b/Vss2Git/app.config
@@ -40,6 +40,9 @@
             <setting name="DefaultComment" serializeAs="String">
                 <value></value>
             </setting>
+            <setting name="EmailMapFile" serializeAs="String">
+                <value>emailmap.xml</value>
+            </setting>
         </Hpdi.Vss2Git.Properties.Settings>
     </userSettings>
 <startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5.2"/></startup></configuration>


### PR DESCRIPTION
Add optional user name to email xml-file mapping

This allows to specify an XML mapping file, which maps VSS user names to email addresses.
VSS user names in the XML file and in VSS are treated case insensitive (both converted to lowercase).
For reading XML-files the references System.Xml and System.Xml.Linq were added to the Visual Studio Vss2Git project.