### PR TITLE
Fix VssPhysicalLib to respect EOF offsets.

### DIFF
--- a/VssPhysicalLib/ItemFile.cs
+++ b/VssPhysicalLib/ItemFile.cs
@@ -79,6 +79,8 @@ namespace Hpdi.VssPhysicalLib
 
         public VssRecord GetNextRecord(bool skipUnknown)
         {
+            if (reader.Offset == this.Header.EofOffset)
+                return null;
             return GetNextRecord<VssRecord>(CreateRecord, skipUnknown);
         }
 
@@ -93,6 +95,8 @@ namespace Hpdi.VssPhysicalLib
 
         public RevisionRecord GetNextRevision(RevisionRecord revision)
         {
+            if (reader.Offset == this.Header.EofOffset)
+                return null;
             reader.Offset = revision.Header.Offset + revision.Header.Length + RecordHeader.LENGTH;
             return GetNextRecord<RevisionRecord>(CreateRevisionRecord, true);
         }

--- a/VssPhysicalLib/ItemFile.cs
+++ b/VssPhysicalLib/ItemFile.cs
@@ -80,7 +80,9 @@ namespace Hpdi.VssPhysicalLib
         public VssRecord GetNextRecord(bool skipUnknown)
         {
             if (reader.Offset == this.Header.EofOffset)
+            {
                 return null;
+            }
             return GetNextRecord<VssRecord>(CreateRecord, skipUnknown);
         }
 
@@ -96,7 +98,9 @@ namespace Hpdi.VssPhysicalLib
         public RevisionRecord GetNextRevision(RevisionRecord revision)
         {
             if (reader.Offset == this.Header.EofOffset)
+            {
                 return null;
+            }
             reader.Offset = revision.Header.Offset + revision.Header.Length + RecordHeader.LENGTH;
             return GetNextRecord<RevisionRecord>(CreateRevisionRecord, true);
         }


### PR DESCRIPTION
Solution proposed by @kornman00 in https://github.com/trevorr/vss2git/issues/47 for the problem 'Attempted read of {0} bytes with only {1} bytes remaining in buffer'.