### PR TITLE
Handle case sensitive directory renames.

### DIFF
--- a/Vss2Git/GitWrapper.cs
+++ b/Vss2Git/GitWrapper.cs
@@ -138,9 +138,18 @@ namespace Hpdi.Vss2Git
             GitExec("rm " + (recursive ? "-r " : "") + "-- " + Quote(path));
         }
 
-        public void Move(string sourcePath, string destPath)
+        public void Move(string sourcePath, string destPath, bool force)
         {
-            GitExec("mv -- " + Quote(sourcePath) + " " + Quote(destPath));
+            if (force)
+            {
+                var tempPath = destPath + ".mvtmp";
+                GitExec("mv -- " + Quote(sourcePath) + " " + Quote(tempPath));
+                GitExec("mv -- " + Quote(tempPath) + " " + Quote(destPath));
+            }
+            else
+            {
+                GitExec("mv -- " + Quote(sourcePath) + " " + Quote(destPath));
+            }
         }
 
         class TempFile : IDisposable


### PR DESCRIPTION
The VSS repository I needed to convert had directories that were renamed where the only difference between the old directory name and new directory name was one of case. The converter then failed on a case-insensitive file system (e.g. NTFS).