### PR TITLE
Support for RestoreFile action

### DIFF
--- a/VssLogicalLib/VssRevision.cs
+++ b/VssLogicalLib/VssRevision.cs
@@ -156,6 +156,7 @@ namespace Hpdi.VssLogicalLib
                             archive.ArchivePath);
                     }
                 case Hpdi.VssPhysicalLib.Action.RestoreProject:
+                case Hpdi.VssPhysicalLib.Action.RestoreFile:
                     {
                         var archive = (ArchiveRevisionRecord)revision;
                         return new VssRestoreAction(db.GetItemName(archive.Name, archive.Physical),

--- a/VssPhysicalLib/ItemFile.cs
+++ b/VssPhysicalLib/ItemFile.cs
@@ -222,6 +222,7 @@ namespace Hpdi.VssPhysicalLib
                     break;
                 case Action.ArchiveProject:
                 case Action.RestoreProject:
+                case Action.RestoreFile:
                     record = new ArchiveRevisionRecord();
                     break;
                 case Action.CreateProject:

--- a/VssPhysicalLib/RevisionRecord.cs
+++ b/VssPhysicalLib/RevisionRecord.cs
@@ -49,6 +49,7 @@ namespace Hpdi.VssPhysicalLib
 
         // archive actions
         ArchiveProject = 23,
+        RestoreFile = 24,
         RestoreProject = 25
     }
 


### PR DESCRIPTION
One of our SourceSafe repositories had RestoreFile actions (24) that were not handled in the code. Realizing that RecoverFile and RecoverProject used pretty much the same code, I was able to get it to work in a similar way by treating RestoreFile similar to RestoreProject.

With this change our repository was migrated successfully and the RestoreFile commits looked healthy.